### PR TITLE
Add maintenance placeholder with alternate contact links

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,13 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Portfolio Under Maintenance</title>
+    <title>Portfolio en Mantenimiento</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
     <main class="maintenance">
-        <h1>Portfolio Under Maintenance</h1>
-        <p>This portfolio is currently under maintenance. In the meantime, you can still reach me through the links below.</p>
+        <h1>Portfolio en Mantenimiento</h1>
+        <p>Este portafolio esta actualmente en mantenimiento. Mientras, toda mi información está en los siguientes links.</p>
         <nav aria-label="Alternate contact links">
             <ul class="link-list">
                 <li>

--- a/index.html
+++ b/index.html
@@ -8,8 +8,8 @@
 </head>
 <body>
     <main class="maintenance">
-        <h1>Portfolio en Mantenimiento</h1>
-        <p>Este portafolio esta actualmente en mantenimiento. Mientras, toda mi información está en los siguientes links.</p>
+        <h1>Página en Mantenimiento</h1>
+        <p>Esta página actualmente está en mantenimiento. Mientras, puedes contactarme a través de los siguientes enlaces.</p>
         <nav aria-label="Alternate contact links">
             <ul class="link-list">
                 <li>

--- a/index.html
+++ b/index.html
@@ -3,47 +3,47 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>My Portfolio</title>
+    <title>Portfolio Under Maintenance</title>
     <link rel="stylesheet" href="style.css">
-<link type="text/css" rel="stylesheet" href="css/style.css"/>
 </head>
 <body>
-    <header>
-    <h1>👨‍💻 My Portfolio</h1>
-    <p>Hello! I’m an aspiring data scientist, excited to grow my skills by working on projects that spark my curiosity.</p>
-</header>
-
-<main>
-    <section id="about">
-        <h2>About Me</h2>
-        <p>
-            I hold a degree in Business and am currently pursuing a master’s program to deepen my knowledge in data science and analytics. My primary expertise lies in Python, complemented by SQL skills and foundational knowledge in web development. I am passionate about using data to derive actionable insights and I enjoy exploring and learning about new tools, technologies, and ideas.
-        </p>
-    </section>
-
-
-
-        <section id="projects">
-            <h2>My Projects</h2>
-            <div class="project">
-                <h3>League of Legends Champion Recommendation app</h3>
-                <p>A simple app that recommends champions to maximize win rate in League of Legends, based on having all other picks.</p>
-                <a href="https://championpickapp-kfii5ncafk9xl3fmcdm6ui.streamlit.app/" target="_blank">Live Demo</a>
-                <a href="https://github.com/NAllendeA/Champion_pick_app">GitHub Repo</a>
-            </div>
-        </section>
-
-        <section id="contact">
-            <h2>Contact Me</h2>
-            <p>Email: <a href="mailto:nallendea@fen.uchile.cl">nallendea@fen.uchile.cl</a></p>
-            <p>LinkedIn: <a href="https://nallendea.github.io/redirect_Linkedin/" target="_blank">Nicolás Allende</a></p>
-            <p>GitHub: <a href="https://github.com/NAllendeA" target="_blank">NAllendeA</a></p>
-        </section>
+    <main class="maintenance">
+        <h1>Portfolio Under Maintenance</h1>
+        <p>This portfolio is currently under maintenance. In the meantime, you can still reach me through the links below.</p>
+        <nav aria-label="Alternate contact links">
+            <ul class="link-list">
+                <li>
+                    <a href="https://linkedin.com/in/nicolas-allende-avalos-22985822a" target="_blank" rel="noopener noreferrer">
+                        <span class="icon" aria-hidden="true">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img">
+                                <path d="M4.98 3.5C4.98 4.88 3.87 6 2.5 6S0 4.88 0 3.5 1.12 1 2.5 1s2.48 1.12 2.48 2.5zM.22 8.5h4.56V23H.22zm7.92 0h4.36v2h.06c.61-1.16 2.1-2.38 4.32-2.38 4.62 0 5.47 3.04 5.47 6.99V23h-4.55v-6.53c0-1.56-.03-3.56-2.17-3.56-2.17 0-2.5 1.69-2.5 3.44V23H8.14z"/>
+                            </svg>
+                        </span>
+                        <span class="label">LinkedIn</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="mailto:nallendeav@gmail.com">
+                        <span class="icon" aria-hidden="true">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img">
+                                <path d="M2 4h20a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2zm0 2v.01L12 13l10-6.99V6H2zm0 12h20V8l-10 7L2 8v10z"/>
+                            </svg>
+                        </span>
+                        <span class="label">Email</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="https://github.com/NAllendeA" target="_blank" rel="noopener noreferrer">
+                        <span class="icon" aria-hidden="true">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img">
+                                <path d="M12 1.5a10.5 10.5 0 0 0-3.32 20.47c.52.1.71-.22.71-.5 0-.24-.01-.87-.01-1.71-2.9.63-3.52-1.4-3.52-1.4-.47-1.2-1.15-1.52-1.15-1.52-.94-.65.07-.64.07-.64 1.04.07 1.58 1.07 1.58 1.07.92 1.57 2.41 1.11 3 .85.09-.67.36-1.12.65-1.38-2.32-.27-4.77-1.16-4.77-5.18 0-1.15.41-2.1 1.07-2.84-.11-.27-.46-1.35.1-2.82 0 0 .88-.28 2.9 1.08a10.04 10.04 0 0 1 5.28 0c2.02-1.36 2.9-1.08 2.9-1.08.56 1.47.22 2.55.11 2.82.66.74 1.06 1.69 1.06 2.84 0 4.03-2.46 4.9-4.8 5.16.37.32.7.94.7 1.9 0 1.37-.01 2.47-.01 2.81 0 .28.19.61.72.5A10.5 10.5 0 0 0 12 1.5z"/>
+                            </svg>
+                        </span>
+                        <span class="label">GitHub</span>
+                    </a>
+                </li>
+            </ul>
+        </nav>
     </main>
-
-    <footer>
-        <p>&copy; 2025 My Portfolio</p>
-    </footer>
-<script type="text/javascript" src="js/script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <body>
     <main class="maintenance">
         <h1>Página en Mantenimiento</h1>
-        <p>Esta página actualmente está en mantenimiento. Mientras, puedes contactarme a través de los siguientes enlaces.</p>
+        <p>Actualmente estoy rediseñando mi pagina de proyectos. Mientras, puedes contactarme a través de Linked-In o Email, o ver mi repositorio de github.</p>
         <nav aria-label="Alternate contact links">
             <ul class="link-list">
                 <li>

--- a/style.css
+++ b/style.css
@@ -1,57 +1,94 @@
-/* General styles */
+:root {
+    color-scheme: dark;
+}
+
+* {
+    box-sizing: border-box;
+}
+
 body {
-    font-family: Arial, sans-serif;
     margin: 0;
-    padding: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #000;
+    color: #fff;
+    font-family: 'Helvetica Neue', Arial, sans-serif;
     line-height: 1.6;
 }
 
-/* Header styles */
-header {
-    background: #333;
-    color: #fff;
+.maintenance {
+    max-width: 32rem;
+    padding: 2.5rem 2rem;
     text-align: center;
-    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
 }
 
-header h1 {
+.maintenance h1 {
+    font-size: clamp(2rem, 6vw, 3rem);
     margin: 0;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
 }
 
-/* Section styles */
-section {
-    margin: 2rem;
+.maintenance p {
+    margin: 0;
+    font-size: 1rem;
+    color: rgba(255, 255, 255, 0.75);
 }
 
-h2 {
-    color: #333;
+.link-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
 }
 
-/* Project cards */
-.project {
-    background: #f4f4f4;
-    padding: 1rem;
-    margin: 1rem 0;
-    border: 1px solid #ddd;
-}
-
-.project a {
-    margin-right: 1rem;
-    color: #007bff;
+.link-list a {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    border-radius: 999px;
     text-decoration: none;
-}
-
-.project a:hover {
-    text-decoration: underline;
-}
-
-/* Footer styles */
-footer {
-    text-align: center;
-    background: #333;
     color: #fff;
-    padding: 1rem;
-    position: relative;
-    bottom: 0;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.link-list a:hover,
+.link-list a:focus-visible {
+    border-color: #fff;
+    transform: translateY(-2px);
+}
+
+.icon {
+    width: 1.5rem;
+    height: 1.5rem;
+    display: inline-flex;
+}
+
+.icon svg {
     width: 100%;
+    height: 100%;
+    fill: currentColor;
+}
+
+@media (min-width: 40rem) {
+    .link-list {
+        flex-direction: row;
+        justify-content: center;
+    }
+
+    .link-list a {
+        min-width: 9rem;
+    }
 }


### PR DESCRIPTION
## Summary
- replace the original portfolio layout with a minimalist maintenance notice
- add prominent links to LinkedIn, email, and GitHub with monochrome icons
- style the page with a centered black-and-white design suited to the temporary state

## Testing
- not run (static assets)

------
https://chatgpt.com/codex/tasks/task_e_690aaa7229b4832db23613ff16b632d2